### PR TITLE
Passing key feature to vectors of locations

### DIFF
--- a/R/geocode.R
+++ b/R/geocode.R
@@ -123,7 +123,7 @@ geocode <- function(location, output = c("latlon", "latlona", "more", "all"),
     locs <- eval(substitute(location), data)
     geocodedLocs <- geocode(locs, output = output, source = source, messaging = messaging,
       override_limit = override_limit, sensor = sensor, client = client,
-      signature = signature)
+      signature = signature, key = key)
     dataSetName <- as.character(substitute(data))
     # this works, but apparently violates crans rules
     message(paste0("overwriting dataset ", dataSetName, "."))

--- a/R/geocode.R
+++ b/R/geocode.R
@@ -151,9 +151,9 @@ geocode <- function(location, output = c("latlon", "latlona", "more", "all"),
 
     # geocode ply and out
     if(output == "latlon" || output == "latlona" || output == "more"){
-      return(ldply(as.list(location), geocode, output = output, source = source, messaging = messaging))
+      return(ldply(as.list(location), geocode, output = output, source = source, messaging = messaging, key = key))
     } else { # output = all
-      return(llply(as.list(location), geocode, output = output, source = source, messaging = messaging))
+      return(llply(as.list(location), geocode, output = output, source = source, messaging = messaging, key = key))
     }
   }
 


### PR DESCRIPTION
Previously, if the locations param was a vector of more than one value, the client and signature params were passed, but not the key. This caused an issue of not being able to do batch geocoding even when in a possession of a paid google geocode API key, which meant people would be blocked at 2500 requests per day instead of 100,000. Passing the key param in the ldply function was a simply addition and fixed the issue. 

Cheers to auburngrads for implementing the API key feature in the first place!
